### PR TITLE
Newcpsammodels

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-cellpose</artifactId>
-			<version>0.0.4</version>
+			<version>0.0.5</version>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/src/main/java/fiji/plugin/appose/cellpose/cp3/CellposeAppose.java
+++ b/src/main/java/fiji/plugin/appose/cellpose/cp3/CellposeAppose.java
@@ -175,7 +175,7 @@ public class CellposeAppose extends DynamicCommand implements Initializable
 	@Parameter(visibility=ItemVisibility.MESSAGE, label=" ", persist = false)
 	private String sysInfo = "";
 
-	@Parameter(label="Torch version", choices = { "cpu", "cu128", "cu130" }, description = "Control which torch/cuda version to use.")
+	@Parameter(label="Torch version", choices = { "cpu", "cu126", "cu130" }, description = "Control which torch/cuda version to use.")
 	private String torchVersion = "cpu";
 
 	@Parameter( label = "use GPU", description = "Run on GPU if available" )

--- a/src/main/java/fiji/plugin/appose/cellpose/cp4/CellposeSAMAppose.java
+++ b/src/main/java/fiji/plugin/appose/cellpose/cp4/CellposeSAMAppose.java
@@ -167,7 +167,7 @@ public class CellposeSAMAppose extends DynamicCommand implements Initializable
 	@Parameter(visibility=ItemVisibility.MESSAGE, label=" ", persist = false)
 	private String sysInfo = "";
 
-	@Parameter(label="Torch version", choices = { "cpu", "cu128", "cu130" }, description = "Control which torch/cuda version to use.")
+	@Parameter(label="Torch version", choices = { "cpu", "cu126", "cu130" }, description = "Control which torch/cuda version to use.")
 	private String torchVersion = "cpu";
 
 	@Parameter( label = "use GPU", description = "Run on GPU if available" )

--- a/src/main/java/fiji/plugin/appose/cellpose/cp4/CellposeSAMAppose.java
+++ b/src/main/java/fiji/plugin/appose/cellpose/cp4/CellposeSAMAppose.java
@@ -65,6 +65,7 @@ import ij.measure.Calibration;
 import ij.plugin.frame.RoiManager;
 import net.imglib2.cellpose.ApposeTaskListener;
 import net.imglib2.cellpose.Cellpose3BuiltinModels;
+import net.imglib2.cellpose.Cellpose4BuiltinModels;
 import net.imglib2.cellpose.Cellpose4Parameters;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
@@ -99,7 +100,6 @@ public class CellposeSAMAppose extends DynamicCommand implements Initializable
 
     @Parameter( label = "Cellpose model", description = "Choose CP model to run" )
 	private Cellpose4BuiltinModels cp_model = Cellpose4BuiltinModels.CPSAMV2; // cellpose model to use, ignored if custom model path is provided
-
     
 	@Parameter( label = "Path to custom model", description = "Custom model path, overrides the Cellpose model", required = false )
 	private String custom_model = ""; // path to custom model, if empty use the selected Cellpose model

--- a/src/main/java/fiji/plugin/appose/cellpose/cp4/CellposeSAMAppose.java
+++ b/src/main/java/fiji/plugin/appose/cellpose/cp4/CellposeSAMAppose.java
@@ -64,6 +64,7 @@ import ij.WindowManager;
 import ij.measure.Calibration;
 import ij.plugin.frame.RoiManager;
 import net.imglib2.cellpose.ApposeTaskListener;
+import net.imglib2.cellpose.Cellpose3BuiltinModels;
 import net.imglib2.cellpose.Cellpose4Parameters;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.numeric.RealType;
@@ -96,6 +97,10 @@ public class CellposeSAMAppose extends DynamicCommand implements Initializable
     @Parameter(visibility=ItemVisibility.MESSAGE, label="<html><b>Cellpose Parameters</b></html>", persist = false)
     private final String initMsg = "<html><hr width='100'></html>";
 
+    @Parameter( label = "Cellpose model", description = "Choose CP model to run" )
+	private Cellpose4BuiltinModels cp_model = Cellpose4BuiltinModels.CPSAMV2; // cellpose model to use, ignored if custom model path is provided
+
+    
 	@Parameter( label = "Path to custom model", description = "Custom model path, overrides the Cellpose model", required = false )
 	private String custom_model = ""; // path to custom model, if empty use the selected Cellpose model
 
@@ -348,6 +353,7 @@ public class CellposeSAMAppose extends DynamicCommand implements Initializable
 		try
 		{
 			final Cellpose4Parameters params = Cellpose4Parameters.builder()
+					.model(cp_model)
 					.customModel(custom_model)
 					.diameter(cell_diameter)
 					.chan0( convertChannelChoiceToInt( chan0, false ) )


### PR DESCRIPTION
Handles new version of CPSAM models (cpsam_v2). Not for now the DINO ones because they are with RGB images.
Most changes are in the imglib2-cellpose which has been merged and the new artifact (0.0.5) is now online.

There's also a modificaiton in the pixi.toml on the imglib2-cellpose to install on mac that don't have 'cmake' install in the system. To see if that works or if user have to do the brew install cmake separatly.